### PR TITLE
telephony: allow broadcasts from Samsung RIL

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -73,6 +73,9 @@
     <protected-broadcast android:name= "com.android.intent.action.IMS_CONFIG_CHANGED" />
     <protected-broadcast android:name= "com.android.ims.REGISTRATION_ERROR" />
     <protected-broadcast android:name= "com.android.phone.vvm.omtp.sms.REQUEST_SENT" />
+    <protected-broadcast android:name= "com.samsung.intent.action.WB_AMR" />
+    <protected-broadcast android:name= "android.intent.action.pcmclkctrl" />
+    <protected-broadcast android:name= "android.intent.action.PHONE_EXSTATE_CHANGED" />
 
     <uses-permission android:name="android.permission.BROADCAST_STICKY" />
     <uses-permission android:name="android.permission.CALL_PHONE" />


### PR DESCRIPTION
RILD triggers message broadcasts using the UNSOL_AM command. These
commands are executed by RILJ. As of Android NG message broadcasts are
only allowed, if the intents are in the protected-broadcast whitelist.
Otherwise the VM will be terminated.

Add the intents used by Samsungs RIL to the protected-broadcast
whitelist.

Change-Id: Idd1bc1c9c68d29ac4a36a9b09a3a5fc5c28af3ee